### PR TITLE
extra-map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea/
+vendor/
+composer.lock
 generated
 !generated/.gitkeep
 src/smarty/templates_c

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,13 @@
   },
   "autoload": {
     "psr-4": {
-      "OxidEsales\\UnifiedNameSpaceGenerator\\": "./src",
+      "OxidEsales\\UnifiedNameSpaceGenerator\\": "src",
       "OxidEsales\\Eshop\\": "./generated/OxidEsales/Eshop"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "OxidEsales\\UnifiedNameSpaceGenerator\\tests\\": "tests"
     }
   },
   "extra": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -24,6 +24,7 @@ namespace OxidEsales\UnifiedNameSpaceGenerator;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
+use Composer\Package\Package;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\ScriptEvents;
 
@@ -100,16 +101,20 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
+     * Collect and merge "extra/oxideshop/unified-namespace-map" entries from composer files.
+     * The root library has the highest priority.
+     *
      * @return string[]
      */
     protected function getExtraMap()
     {
-        $maps = [];
-        foreach ($this->composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
+        $maps     = [];
+        $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getPackages();
+        foreach (array_merge($packages, [$this->composer->getPackage()]) as $package) { /** @var Package $package */
             if (($extra = $package->getExtra()) && isset($extra['oxideshop']['unified-namespace-map'])) {
                 $maps[] = (array)$extra['oxideshop']['unified-namespace-map'];
             }
         }
-        return array_merge(...$maps);
+        return $maps ? array_merge(...$maps) : [];
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -92,8 +92,24 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     protected function getGenerator()
     {
         $facts = new \OxidEsales\Facts\Facts();
-        $unifiedNameSpaceClassMapProvider = new \OxidEsales\UnifiedNameSpaceGenerator\UnifiedNameSpaceClassMapProvider($facts);
 
-        return new \OxidEsales\UnifiedNameSpaceGenerator\Generator($facts, $unifiedNameSpaceClassMapProvider);
+        return new \OxidEsales\UnifiedNameSpaceGenerator\Generator(
+            $facts,
+            new \OxidEsales\UnifiedNameSpaceGenerator\UnifiedNameSpaceClassMapProvider($facts, $this->getExtraMap())
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getExtraMap()
+    {
+        $maps = [];
+        foreach ($this->composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
+            if (($extra = $package->getExtra()) && isset($extra['oxideshop']['unified-namespace-map'])) {
+                $maps[] = (array)$extra['oxideshop']['unified-namespace-map'];
+            }
+        }
+        return array_merge(...$maps);
     }
 }

--- a/src/UnifiedNameSpaceClassMapProvider.php
+++ b/src/UnifiedNameSpaceClassMapProvider.php
@@ -86,7 +86,7 @@ class UnifiedNameSpaceClassMapProvider
             if (!isset($editionSpecificUnifiedNamespaceClassMap[$unifiedClass])) {
                 continue;
             }
-            $editionSpecificUnifiedNamespaceClassMap[$unifiedClass]['editionClassName'] = "\\{$editionClass}::class";
+            $editionSpecificUnifiedNamespaceClassMap[$unifiedClass]['editionClassName'] = "{$editionClass}::class";
         }
         return $editionSpecificUnifiedNamespaceClassMap;
     }

--- a/src/UnifiedNameSpaceClassMapProvider.php
+++ b/src/UnifiedNameSpaceClassMapProvider.php
@@ -86,7 +86,7 @@ class UnifiedNameSpaceClassMapProvider
             if (!isset($editionSpecificUnifiedNamespaceClassMap[$unifiedClass])) {
                 continue;
             }
-            $editionSpecificUnifiedNamespaceClassMap[$unifiedClass]['editionClassName'] = "{$editionClass}::class";
+            $editionSpecificUnifiedNamespaceClassMap[$unifiedClass]['editionClassName'] = $editionClass;
         }
         return $editionSpecificUnifiedNamespaceClassMap;
     }

--- a/src/UnifiedNameSpaceClassMapProvider.php
+++ b/src/UnifiedNameSpaceClassMapProvider.php
@@ -36,11 +36,18 @@ class UnifiedNameSpaceClassMapProvider
     private $facts = null;
 
     /**
-     * @param \OxidEsales\Facts\Facts $facts
+     * @var array
      */
-    public function __construct(\OxidEsales\Facts\Facts $facts)
+    private $extraMap;
+
+    /**
+     * @param \OxidEsales\Facts\Facts $facts
+     * @param array                   $extraMap overwrites editionClassName entries from the current oxid-shop edition
+     */
+    public function __construct(\OxidEsales\Facts\Facts $facts, array $extraMap = null)
     {
         $this->facts = $facts;
+        $this->extraMap = $extraMap;
     }
 
     /**
@@ -69,14 +76,18 @@ class UnifiedNameSpaceClassMapProvider
                     new EnterpriseEditionUnifiedNamespaceClassMap($this->facts);
         }
 
-        if (is_null($unifiedNamespaceClassMap)) {
+        if (!$unifiedNamespaceClassMap) {
             throw new InvalidEditionException(
                 'The OXID eShop edition could not be detected. Be sure to setup your OXID eShop correctly.'
             );
         }
-
         $editionSpecificUnifiedNamespaceClassMap = $unifiedNamespaceClassMap->getClassMap();
-
+        foreach ($this->extraMap ?: []as $unifiedClass => $editionClass) {
+            if (!isset($editionSpecificUnifiedNamespaceClassMap[$unifiedClass])) {
+                continue;
+            }
+            $editionSpecificUnifiedNamespaceClassMap[$unifiedClass]['editionClassName'] = "\\{$editionClass}::class";
+        }
         return $editionSpecificUnifiedNamespaceClassMap;
     }
 }

--- a/tests/Integration/PluginTest.php
+++ b/tests/Integration/PluginTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of OXID eSales Unified Namespaces file generation script.
+ *
+ * OXID eSales Unified Namespaces file generation is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OXID eSales Unified Namespaces file generation script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OXID eSales Unified Namespaces file generation script. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link          http://www.oxid-esales.com
+ * @copyright (C) OXID eSales AG 2003-2017
+ */
+
+namespace OxidEsales\UnifiedNameSpaceGenerator\tests\Integration;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\IO\NullIO;
+use Composer\Package\Package;
+use Composer\Repository\RepositoryManager;
+use Composer\Repository\WritableArrayRepository;
+use OxidEsales\UnifiedNameSpaceGenerator\Plugin;
+
+/**
+ * Class PluginTest
+ *
+ * @package OxidEsales\UnifiedNameSpaceGenerator\tests
+ */
+class PluginTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers \OxidEsales\UnifiedNameSpaceGenerator\Plugin::getExtraMap
+     */
+    public function testGetExtraMap()
+    {
+        $plugin = new Plugin;
+        $plugin->activate($composer = new Composer(), new NullIO);
+        $composer->setRepositoryManager($manager = new RepositoryManager(new NullIO, new Config));
+        $manager->setLocalRepository($repo = new WritableArrayRepository());
+        $repo->addPackage($p1 = new Package(null, null, null));
+        $repo->addPackage(new Package(null, null, null));
+        $repo->addPackage($p2 = new Package(null, null, null));
+
+        $p1->setExtra(['oxideshop' => ['unified-namespace-map' => [
+            'u1' => 'p1e1',
+            'u2' => 'p1e2',
+        ]]]);
+        $p2->setExtra(['oxideshop' => ['unified-namespace-map' => [
+            'u3' => 'p2e1',
+            'u2' => 'p2e2',
+        ]]]);
+
+        $this->markTestIncomplete();
+        // @todo $plugin->callback();
+    }
+}

--- a/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
+++ b/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
@@ -73,9 +73,39 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
     public function providerClassMapsAndEditions()
     {
         return [
+            'with extra map' => [
+                'editiion' => 'CE',
+                'extraMap' => [
+                    'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition' => 'Foo\ConcreteClass',
+                    'OxidEsales\Eshop\AbstractClassExistsInAllEditions' => 'Bar\AbstractClass',
+                ],
+                'expected' => [
+                    'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition'            => [
+                        'editionClassName' => '\Foo\ConcreteClass::class',
+                        'isAbstract'       => false,
+                        'isInterface'      => false
+                    ],
+                    'OxidEsales\Eshop\ClassExistsInCommunityAndProfessionalEdition' => [
+                        'editionClassName' => \OxidEsales\EshopCommunity\ClassExistsInCommunityAndProfessionalEdition::class,
+                        'isAbstract'       => false,
+                        'isInterface'      => false
+                    ],
+                    'OxidEsales\Eshop\ClassExistsInAllEditions'                     => [
+                        'editionClassName' => \OxidEsales\EshopCommunity\ClassExistsInAllEditions::class,
+                        'isAbstract'       => false,
+                        'isInterface'      => false
+                    ],
+                    'OxidEsales\Eshop\AbstractClassExistsInAllEditions'             => [
+                        'editionClassName' => '\Bar\AbstractClass::class',
+                        'isAbstract'       => true,
+                        'isInterface'      => false
+                    ]
+                ]
+            ],
             'ce_edition' => [
-                'CE',
-                [
+                'editiion' => 'CE',
+                'extraMap' => null,
+                'expected' => [
                     'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition'            => [
                         'editionClassName' => \OxidEsales\EshopCommunity\ClassExistsOnlyInCommunityEdition::class,
                         'isAbstract'       => false,
@@ -103,8 +133,9 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
                 ]
             ],
             'pe_edition' => [
-                'PE',
-                [
+                'editiion' => 'PE',
+                'extraMap' => null,
+                'expected' => [
                     'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition'            => [
                         'editionClassName' => \OxidEsales\EshopCommunity\ClassExistsOnlyInCommunityEdition::class,
                         'isAbstract'       => false,
@@ -132,8 +163,9 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
                 ]
             ],
             'ee_edition' => [
-                'EE',
-                [
+                'editiion' => 'EE',
+                'extraMap' => null,
+                'expected' => [
                     'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition'            => [
                         'editionClassName' => \OxidEsales\EshopCommunity\ClassExistsOnlyInCommunityEdition::class,
                         'isAbstract'       => false,
@@ -167,14 +199,15 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
      * @dataProvider providerClassMapsAndEditions
      *
      * @param string $edition
+     * @param array  $extraMap
      * @param array  $expectedClassMap
      */
-    public function testGetClassMapValid($edition, $expectedClassMap)
+    public function testGetClassMapValid($edition, $extraMap, $expectedClassMap)
     {
         $this->copyTestDataIntoVirtualFileSystem('case_valid');
         $factsMock = $this->getFactsMock($edition);
 
-        $unifiedNameSpaceClassMapProvider = new UnifiedNameSpaceClassMapProvider($factsMock);
+        $unifiedNameSpaceClassMapProvider = new UnifiedNameSpaceClassMapProvider($factsMock, $extraMap);
         $this->assertEquals(
             $expectedClassMap,
             $unifiedNameSpaceClassMapProvider->getClassMap(),

--- a/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
+++ b/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
@@ -83,22 +83,26 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
                     'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition'            => [
                         'editionClassName' => 'Foo\ConcreteClass',
                         'isAbstract'       => false,
-                        'isInterface'      => false
+                        'isInterface'      => false,
+                        'isDeprecated'     => false
                     ],
                     'OxidEsales\Eshop\ClassExistsInCommunityAndProfessionalEdition' => [
                         'editionClassName' => \OxidEsales\EshopCommunity\ClassExistsInCommunityAndProfessionalEdition::class,
                         'isAbstract'       => false,
-                        'isInterface'      => false
+                        'isInterface'      => false,
+                        'isDeprecated'     => false
                     ],
                     'OxidEsales\Eshop\ClassExistsInAllEditions'                     => [
                         'editionClassName' => \OxidEsales\EshopCommunity\ClassExistsInAllEditions::class,
                         'isAbstract'       => false,
-                        'isInterface'      => false
+                        'isInterface'      => false,
+                        'isDeprecated'     => false
                     ],
                     'OxidEsales\Eshop\AbstractClassExistsInAllEditions'             => [
                         'editionClassName' => 'Bar\AbstractClass',
                         'isAbstract'       => true,
-                        'isInterface'      => false
+                        'isInterface'      => false,
+                        'isDeprecated'     => false
                     ]
                 ]
             ],

--- a/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
+++ b/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
@@ -81,7 +81,7 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
                 ],
                 'expected' => [
                     'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition'            => [
-                        'editionClassName' => '\Foo\ConcreteClass::class',
+                        'editionClassName' => 'Foo\ConcreteClass::class',
                         'isAbstract'       => false,
                         'isInterface'      => false
                     ],
@@ -96,7 +96,7 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
                         'isInterface'      => false
                     ],
                     'OxidEsales\Eshop\AbstractClassExistsInAllEditions'             => [
-                        'editionClassName' => '\Bar\AbstractClass::class',
+                        'editionClassName' => 'Bar\AbstractClass::class',
                         'isAbstract'       => true,
                         'isInterface'      => false
                     ]

--- a/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
+++ b/tests/Integration/UnifiedNamespaceClassMapProviderTest.php
@@ -81,7 +81,7 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
                 ],
                 'expected' => [
                     'OxidEsales\Eshop\ClassExistsOnlyInCommunityEdition'            => [
-                        'editionClassName' => 'Foo\ConcreteClass::class',
+                        'editionClassName' => 'Foo\ConcreteClass',
                         'isAbstract'       => false,
                         'isInterface'      => false
                     ],
@@ -96,7 +96,7 @@ class UnifiedNamespaceClassMapProviderTest extends \PHPUnit_Framework_TestCase
                         'isInterface'      => false
                     ],
                     'OxidEsales\Eshop\AbstractClassExistsInAllEditions'             => [
-                        'editionClassName' => 'Bar\AbstractClass::class',
+                        'editionClassName' => 'Bar\AbstractClass',
                         'isAbstract'       => true,
                         'isInterface'      => false
                     ]


### PR DESCRIPTION
## An idea, how base classes can be extended by 3rd party libraries

```js
{
  "minimum-stability": "dev",
  "prefer-stable": true,
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/kaluzki/oxideshop-unified-namespace-generator"
    }
  ],
  "require": {
    "php": ">=5.6",
    "oxid-esales/oxideshop-unified-namespace-generator": "dev-extra-map as 1.0.0"
  },
  "require-dev": {
    "oxid-esales/oxideshop-ce": "^6.0",
    "oxid-esales/paypal-module": "^5.1",
    "oxid-esales/oxideshop-demodata-ce": "^6.0"
  },
  "extra": {
    "oxideshop": {
      "unified-namespace-map": {
        "OxidEsales\\Eshop\\Core\\Controller\\BaseController": "kaluzki\\Oxid\\Core\\Controller\\BaseController",
        "OxidEsales\\Eshop\\Core\\Model\\BaseModel": "kaluzki\\Oxid\\Core\\Model\\BaseModel"
      }
    }
  }
}
```